### PR TITLE
Replace static font sizing with responsive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Develops highcharter data visualization using various NACCHO themes
 License: file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 URL: https://github.com/lindsayjorgenson/naccho.viz
 BugReports: https://github.com/lindsayjorgenson/naccho.viz/issues
 Imports: 

--- a/R/pie.R
+++ b/R/pie.R
@@ -8,7 +8,7 @@
 #' @param title_text character string; title of the visualization. Defaults to nothing.
 #' @param subtitle_text character string; subtitle to appear underneath the title. Defaults to nothing.
 #' @param caption_text character string; source and data notes to appear underneath the figure. Defaults to nothing.
-#' @param label_size character such as "13px", defaults to 13px.
+#' @param label_size character such as "13px", defaults to 2.2vmin.
 #' @param legend_enable boolean, TRUE or FALSE, where TRUE enables the legend. Defaults to FALSE.
 #' @param allow_export boolean, TRUE or FALSE, where true allows the visualization to be exported.
 #' @param accessible_desc character string; alternative text description of the figure for screen readers.
@@ -38,7 +38,7 @@ create_pie <- function(data,
                        title_text = "",
                        subtitle_text = NULL,
                        caption_text = NULL,
-                       label_size = "15px",
+                       label_size = "2.5vmin",
                        legend_enable = FALSE,
                        allow_export = TRUE,
                        accessible_desc = "") {

--- a/data-raw/bare.R
+++ b/data-raw/bare.R
@@ -12,20 +12,20 @@ bare <-
         color = naccho.viz::navy,
         fontFamily = "Heebo",
         fontWeight = "bold",
-        fontSize = "20px")
+        fontSize = "3vmin")
     ),
     subtitle = list(
       style = list(
         color = naccho.viz::navy,
         fontFamily = "Heebo",
         fontWeight = "600",
-        fontSize = "15px")
+        fontSize = "2.5vmin")
     ),
     caption = list(
       style = list(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
-        fontSize = "13px")
+        fontSize = "2.2vmin")
     ),
     xAxis = list(
       lineColor = "#fff",
@@ -33,7 +33,7 @@ bare <-
       labels = list(
         style = list(
           fontFamily = "Heebo",
-          fontSize = "14px",
+          fontSize = "2.3vmin",
           fontWeight = "bold",
           textOverflow = 'none',
           color = naccho.viz::grey)
@@ -43,7 +43,7 @@ bare <-
           color = naccho.viz::navy,
           fontFamily = "Heebo",
           fontWeight = "400",
-          fontSize = "15px")
+          fontSize = "2.5vmin")
       )
     ),
     yAxis = list(
@@ -67,21 +67,21 @@ bare <-
           color = naccho.viz::navy,
           fontFamily = "Heebo",
           fontWeight = "500",
-          fontSize = "15px")
+          fontSize = "2.5vmin")
       )
     ),
     legend = list(
       itemStyle = list(
         fontFamily = "Heebo",
         color = naccho.viz::navy,
-        fontSize = "17px",
+        fontSize = "2.7vmin",
         fontWeight = "normal",
         color = "#666"),
       title = list(
         style = list(
           textDecoration = "none",
           fontFamily = "Heebo",
-          fontSize = "16px")
+          fontSize = "2.6vmin")
       )
     ),
     tooltip = list(
@@ -90,8 +90,8 @@ bare <-
       backgroundColor = "#fff",
       style = list(
         fontFamily = "Heebo",
-        fontSize = "16px",
-        lineHeight = "18px")
+        fontSize = "2.6vmin",
+        lineHeight = "2.8vmin")
     ),
     itemHoverStyle = list(
       color = naccho.viz::green

--- a/data-raw/basic.R
+++ b/data-raw/basic.R
@@ -12,20 +12,20 @@ basic <-
         color = naccho.viz::navy,
         fontFamily = "Heebo",
         fontWeight = "bold",
-        fontSize = "20px")
+        fontSize = "3vmin")
     ),
     subtitle = list(
       style = list(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
         fontWeight = "400",
-        fontSize = "15px")
+        fontSize = "2.5vmin")
     ),
     caption = list(
       style = list(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
-        fontSize = "13px")
+        fontSize = "2.2vmin")
     ),
     xAxis = list(
       lineColor = naccho.viz::grey,
@@ -34,7 +34,7 @@ basic <-
       labels = list(
         style = list(
           fontFamily = "Heebo",
-          fontSize = "14px",
+          fontSize = "2.3vmin",
           fontWeight = "bold",
           textOverflow = 'none',
           color = naccho.viz::grey)
@@ -44,7 +44,7 @@ basic <-
           color = naccho.viz::grey,
           fontFamily = "Heebo",
           fontWeight = "400",
-          fontSize = "15px")
+          fontSize = "2.5vmin")
       )
     ),
     yAxis = list(
@@ -59,7 +59,7 @@ basic <-
       labels = list(
         style = list(
           fontFamily = "Heebo",
-          fontSize = "15px",
+          fontSize = "2.5vmin",
           fontWeight = "normal",
           color = naccho.viz::grey)
       ),
@@ -72,21 +72,21 @@ basic <-
           color = naccho.viz::grey,
           fontFamily = "Heebo",
           fontWeight = "700",
-          fontSize = "14px")
+          fontSize = "2.3vmin")
       )
     ),
     legend = list(
       itemStyle = list(
         fontFamily = "Heebo",
         color = naccho.viz::grey,
-        fontSize = "17px",
+        fontSize = "2.7vmin",
         fontWeight = "normal",
         color = "#666"),
       title = list(
         style = list(
           textDecoration = "none",
           fontFamily = "Heebo",
-          fontSize = "16px")
+          fontSize = "2.6vmin")
       )
     ),
     tooltip = list(
@@ -95,9 +95,9 @@ basic <-
       backgroundColor = "#fff",
       style = list(
         fontFamily = "Heebo",
-        fontSize = "16px",
+        fontSize = "2.6vmin",
         fontWeight = "600",
-        lineHeight = "20px")
+        lineHeight = "3vmin")
     ),
     itemHoverStyle = list(
       color = naccho.viz::green

--- a/data-raw/butterfly.R
+++ b/data-raw/butterfly.R
@@ -12,20 +12,20 @@ butterfly <-
         color = naccho.viz::navy,
         fontFamily = "Heebo",
         fontWeight = "bold",
-        fontSize = "20px")
+        fontSize = "3vmin")
     ),
     subtitle = list(
       style = list(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
         fontWeight = "400",
-        fontSize = "15px")
+        fontSize = "2.5vmin")
     ),
     caption = list(
       style = list(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
-        fontSize = "13px")
+        fontSize = "2.2vmin")
     ),
     xAxis = list(
       lineColor = naccho.viz::grey,
@@ -34,7 +34,7 @@ butterfly <-
       labels = list(
         style = list(
           fontFamily = "Heebo",
-          fontSize = "14px",
+          fontSize = "2.3vmin",
           fontWeight = "bold",
           textOverflow = 'none',
           color = naccho.viz::grey)
@@ -44,7 +44,7 @@ butterfly <-
           color = naccho.viz::grey,
           fontFamily = "Heebo",
           fontWeight = "400",
-          fontSize = "15px")
+          fontSize = "2.5vmin")
       )
     ),
     yAxis = list(
@@ -68,7 +68,7 @@ butterfly <-
       labels = list(
         style = list(
           fontFamily = "Heebo",
-          fontSize = "15px",
+          fontSize = "2.5vmin",
           fontWeight = "normal",
           color = naccho.viz::grey)
       ),
@@ -82,21 +82,21 @@ butterfly <-
           color = naccho.viz::grey,
           fontFamily = "Heebo",
           fontWeight = "700",
-          fontSize = "14px")
+          fontSize = "2.3vmin")
       )
     ),
     legend = list(
       itemStyle = list(
         fontFamily = "Heebo",
         color = naccho.viz::grey,
-        fontSize = "17px",
+        fontSize = "2.7vmin",
         fontWeight = "normal",
         color = "#666"),
       title = list(
         style = list(
           textDecoration = "none",
           fontFamily = "Heebo",
-          fontSize = "16px")
+          fontSize = "2.6vmin")
       )
     ),
     tooltip = list(
@@ -106,9 +106,9 @@ butterfly <-
       backgroundColor = "#fff",
       style = list(
         fontFamily = "Heebo",
-        fontSize = "16px",
+        fontSize = "2.6vmin",
         fontWeight = "600",
-        lineHeight = "20px")
+        lineHeight = "3vmin")
     ),
     itemHoverStyle = list(
       color = naccho.viz::green

--- a/data-raw/histogram.R
+++ b/data-raw/histogram.R
@@ -12,20 +12,20 @@ histogram <-
         color = naccho.viz::navy,
         fontFamily = "Heebo",
         fontWeight = "bold",
-        fontSize = "20px")
+        fontSize = "3vmin")
     ),
     subtitle = list(
       style = list(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
         fontWeight = "400",
-        fontSize = "15px")
+        fontSize = "2.5vmin")
     ),
     caption = list(
       style = list(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
-        fontSize = "13px")
+        fontSize = "2.2vmin")
     ),
     xAxis = list(
       lineColor = naccho.viz::grey,
@@ -37,7 +37,7 @@ histogram <-
       labels = list(
         style = list(
           fontFamily = "Heebo",
-          fontSize = "17px",
+          fontSize = "2.7vmin",
           fontWeight = "bold",
           textOverflow = 'none',
           color = naccho.viz::grey)
@@ -47,7 +47,7 @@ histogram <-
           color = naccho.viz::grey,
           fontFamily = "Heebo",
           fontWeight = "400",
-          fontSize = "15px")
+          fontSize = "2.5vmin")
       )
     ),
     yAxis = list(
@@ -62,7 +62,7 @@ histogram <-
       labels = list(
         style = list(
           fontFamily = "Heebo",
-          fontSize = "15px",
+          fontSize = "2.5vmin",
           fontWeight = "normal",
           color = naccho.viz::grey)
       ),
@@ -75,21 +75,21 @@ histogram <-
           color = naccho.viz::grey,
           fontFamily = "Heebo",
           fontWeight = "700",
-          fontSize = "14px")
+          fontSize = "2.3vmin")
       )
     ),
     legend = list(
       itemStyle = list(
         fontFamily = "Heebo",
         color = naccho.viz::grey,
-        fontSize = "17px",
+        fontSize = "2.7vmin",
         fontWeight = "normal",
         color = "#666"),
       title = list(
         style = list(
           textDecoration = "none",
           fontFamily = "Heebo",
-          fontSize = "16px")
+          fontSize = "2.6vmin")
       )
     ),
     tooltip = list(
@@ -98,9 +98,9 @@ histogram <-
       backgroundColor = "#fff",
       style = list(
         fontFamily = "Heebo",
-        fontSize = "16px",
+        fontSize = "2.6vmin",
         fontWeight = "600",
-        lineHeight = "20px")
+        lineHeight = "3vmin")
     ),
     itemHoverStyle = list(
       color = naccho.viz::green

--- a/data-raw/line.R
+++ b/data-raw/line.R
@@ -11,20 +11,20 @@ line <-
         color = naccho.viz::navy,
         fontFamily = "Heebo",
         fontWeight = "bold",
-        fontSize = "20px")
+        fontSize = "3vmin")
     ),
     subtitle = list(
       style = list(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
         fontWeight = "400",
-        fontSize = "15px")
+        fontSize = "2.5vmin")
     ),
     caption = list(
       style = list(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
-        fontSize = "13px")
+        fontSize = "2.4vmin")
     ),
     xAxis = list(
       lineWidth = 0,
@@ -36,7 +36,7 @@ line <-
       labels = list(
         style = list(
           fontFamily = "Heebo",
-          fontSize = "17px",
+          fontSize = "2.7vmin",
           fontWeight = "600",
           textOverflow = 'none',
           color = naccho.viz::grey)
@@ -46,7 +46,7 @@ line <-
           color = naccho.viz::grey,
           fontFamily = "Heebo",
           fontWeight = "400",
-          fontSize = "15px")
+          fontSize = "2.5vmin")
       )
     ),
     yAxis = list(
@@ -61,7 +61,7 @@ line <-
       labels = list(
         style = list(
           fontFamily = "Heebo",
-          fontSize = "15px",
+          fontSize = "2.5vmin",
           fontWeight = "normal",
           color = naccho.viz::grey)
       ),
@@ -74,21 +74,21 @@ line <-
           color = naccho.viz::grey,
           fontFamily = "Heebo",
           fontWeight = "700",
-          fontSize = "14px")
+          fontSize = "2.3vmin")
       )
     ),
     legend = list(
       itemStyle = list(
         fontFamily = "Heebo",
         color = naccho.viz::grey,
-        fontSize = "17px",
+        fontSize = "2.7vmin",
         fontWeight = "normal",
         color = "#666"),
       title = list(
         style = list(
           textDecoration = "none",
           fontFamily = "Heebo",
-          fontSize = "16px")
+          fontSize = "2.6vmin")
       )
     ),
     tooltip = list(
@@ -97,9 +97,9 @@ line <-
       backgroundColor = "#fff",
       style = list(
         fontFamily = "Heebo",
-        fontSize = "16px",
+        fontSize = "2.6vmin",
         fontWeight = "600",
-        lineHeight = "20px")
+        lineHeight = "3vmin")
     ),
     itemHoverStyle = list(
       color = naccho.viz::green

--- a/data-raw/minimal.R
+++ b/data-raw/minimal.R
@@ -12,20 +12,20 @@ minimal <-
         color = naccho.viz::navy,
         fontFamily = "Heebo",
         fontWeight = "bold",
-        fontSize = "20px")
+        fontSize = "3vmin")
     ),
     subtitle = list(
       style = list(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
         fontWeight = "400",
-        fontSize = "15px")
+        fontSize = "2.5vmin")
     ),
     caption = list(
       style = list(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
-        fontSize = "13px")
+        fontSize = "2.2vmin")
     ),
     xAxis = list(
       lineColor = naccho.viz::grey,
@@ -33,7 +33,7 @@ minimal <-
       labels = list(
         style = list(
           fontFamily = "Heebo",
-          fontSize = "14px",
+          fontSize = "2.3vmin",
           fontWeight = "bold",
           textOverflow = 'none',
           color = naccho.viz::grey)
@@ -43,7 +43,7 @@ minimal <-
           color = naccho.viz::grey,
           fontFamily = "Heebo",
           fontWeight = "400",
-          fontSize = "15px")
+          fontSize = "2.5vmin")
       )
     ),
     yAxis = list(
@@ -59,7 +59,7 @@ minimal <-
       labels = list(
         style = list(
           fontFamily = "Heebo",
-          fontSize = "15px",
+          fontSize = "2.5vmin",
           fontWeight = "normal",
           color = naccho.viz::grey)
       ),
@@ -72,21 +72,21 @@ minimal <-
           color = naccho.viz::grey,
           fontFamily = "Heebo",
           fontWeight = "700",
-          fontSize = "14px")
+          fontSize = "2.3vmin")
       )
     ),
     legend = list(
       itemStyle = list(
         fontFamily = "Heebo",
         color = naccho.viz::grey,
-        fontSize = "17px",
+        fontSize = "2.7vmin",
         fontWeight = "normal",
         color = "#666"),
       title = list(
         style = list(
           textDecoration = "none",
           fontFamily = "Heebo",
-          fontSize = "16px")
+          fontSize = "2.6vmin")
       )
     ),
     tooltip = list(
@@ -95,9 +95,9 @@ minimal <-
       backgroundColor = "#fff",
       style = list(
         fontFamily = "Heebo",
-        fontSize = "16px",
+        fontSize = "2.6vmin",
         fontWeight = "400",
-        lineHeight = "18px")
+        lineHeight = "2.8vmin")
     ),
     itemHoverStyle = list(
       color = naccho.viz::green

--- a/data-raw/scatter.R
+++ b/data-raw/scatter.R
@@ -11,7 +11,7 @@ scatter <- highcharter::hc_theme(
       color = naccho.viz::navy,
       fontFamily = "Heebo",
       fontWeight = "700",
-      fontSize = "20px"
+      fontSize = "3vmin"
     )
   ),
   subtitle = list(
@@ -19,14 +19,14 @@ scatter <- highcharter::hc_theme(
       color = naccho.viz::grey,
       fontFamily = "Heebo",
       fontWeight = "400",
-      fontSize = "15px"
+      fontSize = "2.5vmin"
     )
   ),
   caption = list(
     style = list(
       color = naccho.viz::grey,
       fontFamily = "Heebo",
-      fontSize = "13px"
+      fontSize = "2.2vmin"
     )
   ),
   xAxis = list(
@@ -40,7 +40,7 @@ scatter <- highcharter::hc_theme(
     labels = list(
       style = list(
         fontFamily = "Heebo",
-        fontSize = "12px",
+        fontSize = "2vmin",
         fontWeight = "300",
         textOverflow = "none",
         color = naccho.viz::grey
@@ -52,7 +52,7 @@ scatter <- highcharter::hc_theme(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
         fontWeight = "600",
-        fontSize = "14px"
+        fontSize = "2.3vmin"
       )
     ),
     plotLines = list(
@@ -62,7 +62,7 @@ scatter <- highcharter::hc_theme(
       label = list(
         style = list(
           fontFamily = "Heebo",
-          fontSize = "12px",
+          fontSize = "2vmin",
           fontWeight = "300",
           textOverflow = "none",
           color = naccho.viz::grey
@@ -82,7 +82,7 @@ scatter <- highcharter::hc_theme(
     labels = list(
       style = list(
         fontFamily = "Heebo",
-        fontSize = "12px",
+        fontSize = "2vmin",
         fontWeight = "300",
         textOverflow = "none",
         color = naccho.viz::grey
@@ -94,7 +94,7 @@ scatter <- highcharter::hc_theme(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
         fontWeight = "600",
-        fontSize = "14px"
+        fontSize = "2.3vmin"
       )
     ),
     plotLines = list(
@@ -104,7 +104,7 @@ scatter <- highcharter::hc_theme(
       label = list(
         style = list(
           fontFamily = "Heebo",
-          fontSize = "12px",
+          fontSize = "2vmin",
           fontWeight = "300",
           textOverflow = "none",
           color = naccho.viz::grey
@@ -116,14 +116,14 @@ scatter <- highcharter::hc_theme(
     itemStyle = list(
       fontFamily = "Heebo",
       color = naccho.viz::grey,
-      fontSize = "15px",
+      fontSize = "2.5vmin",
       fontWeight = "normal"
     ),
     title = list(
       style = list(
         textDecoration = "none",
         fontFamily = "Heebo",
-        fontSize = "16px"
+        fontSize = "2.6vmin"
       )
     )
   ),
@@ -133,9 +133,9 @@ scatter <- highcharter::hc_theme(
     backgroundColor = "#fff",
     style = list(
       fontFamily = "Heebo",
-      fontSize = "16px",
+      fontSize = "2.6vmin",
       fontWeight = "600",
-      lineHeight = "20px"
+      lineHeight = "3vmin"
     )
   ),
   plotOptions = list(
@@ -151,7 +151,7 @@ scatter <- highcharter::hc_theme(
       style = list(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
-        fontSize = "16px"
+        fontSize = "2.6vmin"
       )
     )
   )

--- a/data-raw/tick.R
+++ b/data-raw/tick.R
@@ -12,27 +12,27 @@ tick <-
         color = naccho.viz::navy,
         fontFamily = "Heebo",
         fontWeight = "bold",
-        fontSize = "20px")
+        fontSize = "3vmin")
     ),
     subtitle = list(
       style = list(
         color = naccho.viz::navy,
         fontFamily = "Heebo",
         fontWeight = "600",
-        fontSize = "15px")
+        fontSize = "2.5vmin")
     ),
     caption = list(
       style = list(
         color = naccho.viz::grey,
         fontFamily = "Heebo",
-        fontSize = "13px")
+        fontSize = "2.2vmin")
     ),
     xAxis = list(
       lineColor = naccho.viz::grey,
       labels = list(
         style = list(
           fontFamily = "Heebo",
-          fontSize = "22px",
+          fontSize = "3.2vmin",
           fontWeight = "bold",
           textOverflow = 'none',
           color = naccho.viz::grey)
@@ -42,7 +42,7 @@ tick <-
           color = naccho.viz::navy,
           fontFamily = "Heebo",
           fontWeight = "400",
-          fontSize = "15px")
+          fontSize = "2.5vmin")
       )
     ),
     yAxis = list(
@@ -67,21 +67,21 @@ tick <-
           color = naccho.viz::navy,
           fontFamily = "Heebo",
           fontWeight = "500",
-          fontSize = "15px")
+          fontSize = "2.5vmin")
       )
     ),
     legend = list(
       itemStyle = list(
         fontFamily = "Heebo",
         color = naccho.viz::navy,
-        fontSize = "17px",
+        fontSize = "2.7vmin",
         fontWeight = "normal",
         color = "#666"),
       title = list(
         style = list(
           textDecoration = "none",
           fontFamily = "Heebo",
-          fontSize = "16px")
+          fontSize = "2.6vmin")
       )
     ),
     tooltip = list(
@@ -90,8 +90,8 @@ tick <-
       backgroundColor = "#fff",
       style = list(
         fontFamily = "Heebo",
-        fontSize = "16px",
-        lineHeight = "20px")
+        fontSize = "2.6vmin",
+        lineHeight = "3vmin")
     ),
     itemHoverStyle = list(
       color = naccho.viz::green

--- a/man/create_pie.Rd
+++ b/man/create_pie.Rd
@@ -13,7 +13,7 @@ create_pie(
   title_text = "",
   subtitle_text = NULL,
   caption_text = NULL,
-  label_size = "15px",
+  label_size = "2.5vmin",
   legend_enable = FALSE,
   allow_export = TRUE,
   accessible_desc = ""
@@ -36,7 +36,7 @@ create_pie(
 
 \item{caption_text}{character string; source and data notes to appear underneath the figure. Defaults to nothing.}
 
-\item{label_size}{character such as "13px", defaults to 13px.}
+\item{label_size}{character such as "13px", defaults to 2.2vmin.}
 
 \item{legend_enable}{boolean, TRUE or FALSE, where TRUE enables the legend. Defaults to FALSE.}
 

--- a/man/create_single_bar.Rd
+++ b/man/create_single_bar.Rd
@@ -11,7 +11,7 @@ create_single_bar(
   y_variable,
   tick_amount = 6,
   color_bars = FALSE,
-  y_label,
+  y_label = "",
   y_max = 100,
   y_format = "{value:,.0f}",
   my_colors = naccho.viz::colors,
@@ -21,7 +21,7 @@ create_single_bar(
   caption_align = "center",
   legend_enable = FALSE,
   legend_title = "",
-  tooltip,
+  tooltip = NULL,
   select_theme = naccho.viz::minimal,
   allow_export = TRUE,
   accessible_desc = ""


### PR DESCRIPTION
Changing static px to vmin to better account for responsive screen resizing, etc. 

> ### **_For reference:_**
>> - 12px - 2vmin
>> - 13px - 2.2vmin
>> - 14px - 2.3vmin
>> - 15px - 2.5vmin
>> - 20px - 3vmin
>> - 30px - 4vmin
>
> _it follows the same pattern from 2.5vmin and on_